### PR TITLE
Add support for array as formal parameters and array elements as live lvalues

### DIFF
--- a/generate.ml
+++ b/generate.ml
@@ -149,14 +149,12 @@ let gen_const typ =
 let gen_array_elt (lhost, offset as lval) =
   match Cil.typeOfLval lval with
   | TArray (_, e, _, _) ->
-    (* Generate random array index in [0, array_length - 1], just for the last
-       array dimension. *)
     let offset =
       match offset with
       | NoOffset ->
         Index (Cil.(integer ~loc (Random.int (lenOfArray e))), NoOffset)
       | _ ->
-        offset
+        assert false
     in
     lhost, offset
   | typ ->

--- a/generate.ml
+++ b/generate.ml
@@ -146,11 +146,38 @@ let gen_const typ =
   | _ ->
     Cil.mkCast ~force:false ~e:(Cil.zero ~loc) ~newt:typ
 
+let gen_array_elt (lhost, offset as lval) =
+  match Cil.typeOfLval lval with
+  | TArray (_, e, _, _) ->
+    (* Generate random array index in [0, array_length - 1], just for the last
+       array dimension. *)
+    let offset =
+      match offset with
+      | NoOffset ->
+        Index (Cil.(integer ~loc (Random.int (lenOfArray e))), NoOffset)
+      | _ ->
+        offset
+    in
+    lhost, offset
+  | typ ->
+    let err_msg =
+      Format.asprintf
+        "Expected lvalue of array type, got `%a'."
+        Cil_printer.pp_typ typ
+    in
+    raise (Invalid_argument err_msg)
+
 (* Initialize a local variable to a constant or a parameter. *)
 let gen_local_init lval =
   let gen_param_use typ =
     if not (LvalSet.is_empty !param_lvals) then
       let lval = Utils.random_select_from_set !param_lvals in
+      let lval =
+        if Cil.(isArrayType (typeOfLval lval)) then
+          gen_array_elt lval
+        else
+          lval
+      in
       let e = Cil.new_exp ~loc (Lval lval) in
       Cil.mkCast ~force:false ~e ~newt:typ
     else
@@ -163,23 +190,46 @@ let gen_local_init lval =
   Cil.mkStmtOneInstr ~valid_sid:true assign
 
 let new_lval () =
-  if List.length !fundec.sformals < Options.MaxArgs.get () &&
-     Options.PointerArgs.get () &&
-     Random.float 1.0 < 0.1
-  then
-    (* Make a parameter of pointer type. *)
-    let ptr_typ = TPtr (gen_type (), []) in
-    let vi = gen_formal_var ptr_typ in
+  let typ = gen_type () in
+  let vi =
+    if List.length !fundec.sformals < Options.MaxArgs.get () &&
+       (Options.PointerArgs.get () || Options.Arrays.get ()) &&
+       Random.float 1.0 < 0.1
+    then
+      (* Make a parameter of pointer or array type. *)
+      let ptr_or_array_typ =
+        let types =
+          if Options.PointerArgs.get () then
+            [TPtr (typ, [])]
+          else
+            []
+        in
+        let types =
+          if Options.Arrays.get () then
+            let length = Random.int (Options.MaxArrayLength.get ()) + 1 in
+            (* One-dimensional array. *)
+            TArray
+              (typ,
+               Some (Cil.integer ~loc length),
+               { scache = Not_Computed },
+               [])
+            :: types
+          else
+            types
+        in
+        Utils.random_select types
+      in
+      gen_formal_var ptr_or_array_typ
+    else
+      (* Make a plain variable. *)
+      let vi = gen_var typ in
+      vi.vreferenced <- true;
+      vi
+  in
+  if Cil.isPointerType vi.vtype then
     (Mem (Cil.evar vi), NoOffset)
   else
-    (* Make a plain variable. *)
-    let vi = gen_var (gen_type ()) in
-    vi.vreferenced <- true;
-    (* This may be a previously known parameter variable of pointer type. *)
-    if Cil.isPointerType vi.vtype then
-      (Mem (Cil.evar vi), NoOffset)
-    else
-      (Var vi, NoOffset)
+    (Var vi, NoOffset)
 
 let gen_lval_use ~num_live () =
   (* Select a known local var or parameter of the function, or generate a
@@ -207,6 +257,14 @@ let gen_lval_use ~num_live () =
     else
       let f = Utils.random_select [use_param; use_local] in
       f ()
+  in
+  let lval =
+    (* Array are generated as a single lvalue with array type. Here we need to
+       actually pick an element of the array [lval]. *)
+    if Cil.(isArrayType (typeOfLval lval)) then
+      gen_array_elt lval
+    else
+      lval
   in
   (* We never want to generate assignments to the function's formal
      parameters. This is easy: We simply never put them into the live set,

--- a/options.ml
+++ b/options.ml
@@ -78,7 +78,7 @@ module MaxArgs = Int
     let help = "set maximal number of function arguments"
   end)
 
-module Arrays = False
+module Arrays = True
   (struct
     let option_name = "-ldrgen-arrays"
     let help = "allow generation of arrays"

--- a/options.ml
+++ b/options.ml
@@ -78,6 +78,20 @@ module MaxArgs = Int
     let help = "set maximal number of function arguments"
   end)
 
+module Arrays = False
+  (struct
+    let option_name = "-ldrgen-arrays"
+    let help = "allow generation of arrays"
+  end)
+
+module MaxArrayLength = Int
+  (struct
+    let option_name = "-ldrgen-max-array-length"
+    let arg_name = "n"
+    let default = 5
+    let help = "set maximal number of array elements"
+  end)
+
 module FloatingPoint = True
   (struct
     let option_name = "-ldrgen-fp"

--- a/options.mli
+++ b/options.mli
@@ -28,6 +28,8 @@ module StmtDepth: Parameter_sig.Int
 module BlockLength: Parameter_sig.Int
 module MaxLive: Parameter_sig.Int
 module MaxArgs: Parameter_sig.Int
+module Arrays: Parameter_sig.Bool
+module MaxArrayLength: Parameter_sig.Int
 
 module FloatingPoint: Parameter_sig.Bool
 module Float: Parameter_sig.Bool


### PR DESCRIPTION
This PR adds support for:
- arrays as formal parameters,
- array elements as live lvalues (hence used in expressions).